### PR TITLE
python setuptools version 50.3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 # This is a list of python packages needed for ESP-IDF. This file is used with pip.
 # Please see the Get Started section of the ESP-IDF Programming Guide for further information.
 #
-setuptools==51.1.2
+setuptools==50.3.2
 # The setuptools package is required to install source distributions and on some systems is not installed by default.
 # Please keep it as the first item of this list.
 #


### PR DESCRIPTION
fix python setuptools to   version to 50.3.2 avoid issue when installing the python requirement with further pip versions.